### PR TITLE
Bugfix: Make sure the plugin will not give a parse error on PHP < 5.3

### DIFF
--- a/class-debug-bar-action-and-filters-addon.php
+++ b/class-debug-bar-action-and-filters-addon.php
@@ -5,7 +5,7 @@
  *
  * @author  subharanjan
  * @package debug-bar-actions-and-filters-addon
- * @version 1.4
+ * @version 1.4.1
  */ 
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly 

--- a/debug-bar-action-and-filters-addon.php
+++ b/debug-bar-action-and-filters-addon.php
@@ -3,7 +3,7 @@
  * Plugin Name: Debug Bar Actions and Filters Addon
  * Plugin URI: http://wordpress.org/extend/plugins/debug-bar-actions-and-filters-addon/
  * Description: This plugin add two more tabs in the Debug Bar to display hooks(Actions and Filters) attached to the current request. Actions tab displays the actions hooked to current request. Filters tab displays the filter tags along with the functions attached to it with priority.
- * Version: 1.4
+ * Version: 1.4.1
  * Author: Subharanjan
  * Author Email: subharanjanmantri@gmail.com
  * Author URI: http://www.subharanjan.in/
@@ -11,7 +11,7 @@
  *  
  * @author  subharanjan
  * @package debug-bar-actions-and-filters-addon
- * @version 1.4
+ * @version 1.4.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly 

--- a/php5.3-closure-test.php
+++ b/php5.3-closure-test.php
@@ -1,5 +1,12 @@
 <?php
-
+/**
+ * PHP 5.3+ functionality in a separate file
+ *
+ * @since 1.4.1
+ * @author  subharanjan
+ * @package debug-bar-actions-and-filters-addon
+ * @version 1.4.1
+ */
 if( ! function_exists( 'debug_bar_action_and_filters_addon_is_closure' ) ) {
 	/**
 	 * Function to check for closures

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: subharanjan
 Tags: Debug Bar, Actions, Filters, Debug Bar Actions Display, Debug Bar Filters Display, List Hooks attached, List of Hooks Fired, Developer's tool for action and filter hooks
 Requires at least: 3.3
 Tested up to: 3.8
-Stable tag: 1.4
+Stable tag: 1.4.1
 License: GPLv2
 
 This plugin adds two more tabs in the Debug Bar to display all the hooks(Actions and Filters) for the current request. Requires "Debug Bar" plugin.
@@ -58,6 +58,9 @@ And: Please don't use this on live site. This is only for development purpose.
 Adding the initial plugin to Wordpress plugins directory.
 
 == Upgrade Notice ==
+
+= 1.4.1 =
+Bug fix for users still on PHP 5.2.
 
 = 1.4 =
 Fixed serious bug - upgrade highly recommended.


### PR DESCRIPTION
As closures are only available on PHP 5.3+, having one in a file used on PHP 5.2 (which is still the official WP minimum requirement), will give a parse error and bork the whole website on which the plugin is installed....

Just came across it while testing another plugin on various PHP versions.
