### PR TITLE
Leaner language loading.

### DIFF
--- a/class-debug-bar-action-and-filters-addon.php
+++ b/class-debug-bar-action-and-filters-addon.php
@@ -24,7 +24,11 @@ class Debug_Bar_Actions_Filters_Addon extends Debug_Bar_Panel {
 
 	public function init() {
 		$this->title( $this->tab );
-		load_plugin_textdomain( 'debug-bar-actions-and-filters-addon', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+
+		if ( ! is_textdomain_loaded( 'debug-bar-actions-and-filters-addon' ) ) {
+			load_plugin_textdomain( 'debug-bar-actions-and-filters-addon', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+		}
+
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 	}


### PR DESCRIPTION
As two panels are being added, the constructor is called twice and the load_textdomain call leads to four extra file requests.
Now fixed.