### PR TITLE
Defer to the `wp-content/languages` directory for the loading of translations.

### DIFF
--- a/class-debug-bar-action-and-filters-addon.php
+++ b/class-debug-bar-action-and-filters-addon.php
@@ -25,10 +25,6 @@ class Debug_Bar_Actions_Filters_Addon extends Debug_Bar_Panel {
 	public function init() {
 		$this->title( $this->tab );
 
-		if ( ! is_textdomain_loaded( 'debug-bar-actions-and-filters-addon' ) ) {
-			load_plugin_textdomain( 'debug-bar-actions-and-filters-addon', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-		}
-
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 	}

--- a/debug-bar-action-and-filters-addon.php
+++ b/debug-bar-action-and-filters-addon.php
@@ -49,15 +49,18 @@ add_action( 'admin_init', 'debug_bar_action_and_filters_addon_has_parent_plugin'
  */
 if ( ! function_exists( 'debug_bar_action_and_filters_addon_panel' ) ) {
 	function debug_bar_action_and_filters_addon_panel( $panels ) {
+		load_plugin_textdomain( 'debug-bar-actions-and-filters-addon' );
+
 		require_once( plugin_dir_path( __FILE__ ) . 'class-debug-bar-action-and-filters-addon.php' );
 
-		$panels[] = new Debug_Bar_Actions_Addon_Panel( 'Action Hooks', 'debug_bar_action_and_filters_addon_display_actions' );
-		$panels[] = new Debug_Bar_Filters_Addon_Panel( 'Filter Hooks', 'debug_bar_action_and_filters_addon_display_filters' );
+		$panels[] = new Debug_Bar_Actions_Addon_Panel( __( 'Action Hooks', 'debug-bar-actions-and-filters-addon' ), 'debug_bar_action_and_filters_addon_display_actions' );
+		$panels[] = new Debug_Bar_Filters_Addon_Panel( __( 'Filter Hooks', 'debug-bar-actions-and-filters-addon' ), 'debug_bar_action_and_filters_addon_display_filters' );
 
 		return $panels;
 	}
 }
 add_filter( 'debug_bar_panels', 'debug_bar_action_and_filters_addon_panel' );
+
 
 /**
  * Function to display the Actions attached to current request.

--- a/languages/debug-bar-actions-and-filters-addon.pot
+++ b/languages/debug-bar-actions-and-filters-addon.pot
@@ -1,62 +1,79 @@
-# Copyright (C) 2016 Debug Bar Actions and Filters Addon
-# This file is distributed under the same license as the Debug Bar Actions and Filters Addon package.
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Debug Bar Actions and Filters Addon 1.5\n"
-"Report-Msgid-Bugs-To: http://wordpress.org/support/plugin/git\n"
-"POT-Creation-Date: 2016-01-06 15:42:19+00:00\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Project-Id-Version: Debug Bar Actions and Filters Addon\n"
+"POT-Creation-Date: 2016-05-07 02:23+0200\n"
+"PO-Revision-Date: 2016-04-14 13:28+0200\n"
+"Last-Translator: Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2016-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"X-Generator: Poedit 1.8.7\n"
+"X-Poedit-Basepath: ..\n"
+"X-Poedit-WPHeader: debug-bar-action-and-filters-addon.php\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
+"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
+"_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-SearchPathExcluded-0: *.js\n"
 
-#: debug-bar-action-and-filters-addon.php:72
+#: debug-bar-action-and-filters-addon.php:56
+msgid "Action Hooks"
+msgstr ""
+
+#: debug-bar-action-and-filters-addon.php:57
+msgid "Filter Hooks"
+msgstr ""
+
+#: debug-bar-action-and-filters-addon.php:75
 msgid "Total Actions in this page load:"
 msgstr ""
 
-#: debug-bar-action-and-filters-addon.php:73
+#: debug-bar-action-and-filters-addon.php:76
 msgid "List of Action Hooks"
 msgstr ""
 
-#: debug-bar-action-and-filters-addon.php:117
+#: debug-bar-action-and-filters-addon.php:120
 msgid "Hook"
 msgstr ""
 
-#: debug-bar-action-and-filters-addon.php:118
+#: debug-bar-action-and-filters-addon.php:121
 msgid "Priority"
 msgstr ""
 
-#: debug-bar-action-and-filters-addon.php:119
+#: debug-bar-action-and-filters-addon.php:122
 msgid "Registered callbacks"
 msgstr ""
 
-#: debug-bar-action-and-filters-addon.php:165
-#: debug-bar-action-and-filters-addon.php:169
+#: debug-bar-action-and-filters-addon.php:168
+#: debug-bar-action-and-filters-addon.php:172
 msgid "closure"
 msgstr ""
 
-#: debug-bar-action-and-filters-addon.php:178
-#: debug-bar-action-and-filters-addon.php:182
+#: debug-bar-action-and-filters-addon.php:181
+#: debug-bar-action-and-filters-addon.php:185
 msgid "class"
 msgstr ""
 
-#: debug-bar-action-and-filters-addon.php:186
+#: debug-bar-action-and-filters-addon.php:189
 msgid "object"
 msgstr ""
 
-#: debug-bar-action-and-filters-addon.php:211
+#: debug-bar-action-and-filters-addon.php:214
 msgid "Total hooks with registered actions/filters:"
 msgstr ""
 
-#: debug-bar-action-and-filters-addon.php:212
+#: debug-bar-action-and-filters-addon.php:215
 msgid "Total registered callbacks:"
 msgstr ""
 
-#: debug-bar-action-and-filters-addon.php:213
+#: debug-bar-action-and-filters-addon.php:216
 msgid "Unique registered callbacks:"
 msgstr ""
+
 #. Plugin Name of the plugin/theme
 msgid "Debug Bar Actions and Filters Addon"
 msgstr ""
@@ -66,7 +83,11 @@ msgid "https://wordpress.org/plugins/debug-bar-actions-and-filters-addon/"
 msgstr ""
 
 #. Description of the plugin/theme
-msgid "This plugin add two more tabs in the Debug Bar to display hooks(Actions and Filters) attached to the current request. Actions tab displays the actions hooked to current request. Filters tab displays the filter tags along with the functions attached to it with priority."
+msgid ""
+"This plugin add two more tabs in the Debug Bar to display hooks(Actions and "
+"Filters) attached to the current request. Actions tab displays the actions "
+"hooked to current request. Filters tab displays the filter tags along with "
+"the functions attached to it with priority."
 msgstr ""
 
 #. Author of the plugin/theme

--- a/readme.txt
+++ b/readme.txt
@@ -50,9 +50,12 @@ This plugin is only meant to be used for development purposes, but shouldn't cau
 
 == Changelog ==
 
+= Trunk =
+* Defer to translation retrieved from GlotPress, leaner language loading and language loading now compatible with use of the plugin in the `must-use` plugins directory - props [Jrf](http://profiles.wordpress.org/jrf)
+
 = 1.5.1 =
-* Leaner language loading.
-* Fix some layout issues.
+* Leaner language loading - props [Jrf](http://profiles.wordpress.org/jrf)
+* Fix some layout issues - props [Jrf](http://profiles.wordpress.org/jrf)
 
 = 1.5 =
 * Show total hooks run at the top of the action hooks panel - props [Jrf](http://profiles.wordpress.org/jrf).


### PR DESCRIPTION
As there are currently no translations available, this will make the loading of the text-domain compatible with use of the plugin in the `must-use` plugins directory.

Also:
- make two more strings translatable
- make sure WP only tries to load the language files ones.
