### PR TITLE
Fix compatibility with WP 4.7

### DIFF
--- a/debug-bar-action-and-filters-addon.php
+++ b/debug-bar-action-and-filters-addon.php
@@ -129,6 +129,10 @@ function debug_bar_action_and_filters_addon_display_filters() {
 	$hook_in_count        = 0;
 	$callbacks_registered = array();
 	foreach ( $wp_filter as $filter_key => $filter_val ) {
+		if ( $filter_val instanceof WP_Hook ) {
+			$filter_val = $filter_val->callbacks;
+		}
+
 		$filter_count = count( $filter_val );
 
 		$rowspan = '';


### PR DESCRIPTION
Fix compatibility with WP 4.7 where filters are now instances of the WP_Hook class.

See: https://make.wordpress.org/core/2016/09/08/wp_hook-next-generation-actions-and-filters/
See: https://developer.wordpress.org/reference/classes/wp_hook/

Without this fix, the filter tab does not display properly and lots of `PHP Warning:  ksort() expects parameter 1 to be array, object given in /path/to/debug-bar-actions-and-filters/debug-bar-action-and-filters-addon.php on line 144` are thrown