### PR TITLE
Please license with "or later"

### DIFF
--- a/debug-bar-action-and-filters-addon.php
+++ b/debug-bar-action-and-filters-addon.php
@@ -10,7 +10,7 @@
  * Depends: Debug Bar
  * Text Domain: debug-bar-actions-and-filters-addon
  * Domain Path: /languages
- * License: GPLv2
+ * License: GPLv2 or later
  *
  * @author  subharanjan
  * @package debug-bar-actions-and-filters-addon


### PR DESCRIPTION
I like to copy and paste the `debug_bar_action_and_filters_addon_display_filters` into my GPLv3 plugin for debugging, but I can not legally do this with GPLv2